### PR TITLE
send the pipeline slug to ci-stats

### DIFF
--- a/dist/ci-stats/client.js
+++ b/dist/ci-stats/client.js
@@ -7,7 +7,7 @@ class CiStatsClient {
         var _a, _b;
         this.createBuild = async () => {
             const resp = await this.http.post('/v1/build', {
-                jenkinsJobName: process.env.BUILDKITE_PIPELINE_NAME,
+                jenkinsJobName: process.env.BUILDKITE_PIPELINE_SLUG,
                 jenkinsJobId: process.env.BUILDKITE_BUILD_ID,
                 jenkinsUrl: process.env.BUILDKITE_BUILD_URL,
                 prId: process.env.GITHUB_PR_NUMBER || null,

--- a/src/ci-stats/client.ts
+++ b/src/ci-stats/client.ts
@@ -31,7 +31,7 @@ export class CiStatsClient {
 
   createBuild = async (): Promise<CiStatsBuild> => {
     const resp = await this.http.post('/v1/build', {
-      jenkinsJobName: process.env.BUILDKITE_PIPELINE_NAME,
+      jenkinsJobName: process.env.BUILDKITE_PIPELINE_SLUG,
       jenkinsJobId: process.env.BUILDKITE_BUILD_ID,
       jenkinsUrl: process.env.BUILDKITE_BUILD_URL,
       prId: process.env.GITHUB_PR_NUMBER || null,


### PR DESCRIPTION
In order to be able to use the BK API to read job info we need the slug, not the display name.