### PR TITLE
[ci] Use org wide PR comment bot

### DIFF
--- a/dist/test-failures/annotate.js
+++ b/dist/test-failures/annotate.js
@@ -99,10 +99,10 @@ const annotateTestFailures = async () => {
         .filter((f) => f)
         .sort((a, b) => a.name.localeCompare(b.name));
     buildkite.setAnnotation('test_failures', 'error', (0, exports.getAnnotation)(failures, failureHtmlArtifacts));
-    if (process.env.PR_COMMENTS_ENABLED === 'true') {
+    if (process.env.ELASTIC_PR_COMMENTS_ENABLED === 'true') {
         buildkite.setMetadata('pr_comment:test_failures:body', (0, exports.getPrComment)(failures, failureHtmlArtifacts));
     }
-    if (process.env.SLACK_NOTIFICATIONS_ENABLED === 'true') {
+    if (process.env.ELASTIC_SLACK_NOTIFICATIONS_ENABLED === 'true') {
         buildkite.setMetadata('slack:test_failures:body', (0, exports.getSlackMessage)(failures, failureHtmlArtifacts));
     }
 };

--- a/src/test-failures/annotate.ts
+++ b/src/test-failures/annotate.ts
@@ -162,7 +162,7 @@ export const annotateTestFailures = async () => {
 
   buildkite.setAnnotation('test_failures', 'error', getAnnotation(failures, failureHtmlArtifacts));
 
-  if (process.env.PR_COMMENTS_ENABLED === 'true') {
+  if (process.env.ELASTIC_PR_COMMENTS_ENABLED === 'true') {
     buildkite.setMetadata('pr_comment:test_failures:body', getPrComment(failures, failureHtmlArtifacts));
   }
 


### PR DESCRIPTION
@delanni FYI we were missing the dist from https://github.com/elastic/kibana-buildkite-library/pull/28.  I'll bump the version after.