### PR TITLE
Support org wide PR comment bot

### DIFF
--- a/dist/test-failures/annotate.js
+++ b/dist/test-failures/annotate.js
@@ -99,7 +99,7 @@ const annotateTestFailures = async () => {
         .filter((f) => f)
         .sort((a, b) => a.name.localeCompare(b.name));
     buildkite.setAnnotation('test_failures', 'error', (0, exports.getAnnotation)(failures, failureHtmlArtifacts));
-    if (process.env.PR_COMMENTS_ENABLED === 'true') {
+    if (process.env.PR_COMMENTS_ENABLED === 'true' || process.env.ELASTIC_PR_COMMENTS_ENABLED === 'true') {
         buildkite.setMetadata('pr_comment:test_failures:body', (0, exports.getPrComment)(failures, failureHtmlArtifacts));
     }
     if (process.env.ELASTIC_SLACK_NOTIFICATIONS_ENABLED === 'true') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kibana-buildkite-library",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kibana-buildkite-library",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kibana-buildkite-library",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Buildkite Utilities",
   "main": "./dist",
   "types": "./types",

--- a/src/test-failures/annotate.ts
+++ b/src/test-failures/annotate.ts
@@ -162,7 +162,7 @@ export const annotateTestFailures = async () => {
 
   buildkite.setAnnotation('test_failures', 'error', getAnnotation(failures, failureHtmlArtifacts));
 
-  if (process.env.PR_COMMENTS_ENABLED === 'true') {
+  if (process.env.PR_COMMENTS_ENABLED === 'true' || process.env.ELASTIC_PR_COMMENTS_ENABLED === 'true') {
     buildkite.setMetadata('pr_comment:test_failures:body', getPrComment(failures, failureHtmlArtifacts));
   }
 


### PR DESCRIPTION
Reapplies https://github.com/elastic/kibana-buildkite-library/pull/29, except with backwards compatibility to the old version.